### PR TITLE
[Chore] 공통 유틸 함수, API 클라이언트 추가

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /**
+   * 개발 환경 API 프록시 설정
+   * 프론트엔드(3000) → 백엔드(8080) 요청 시 CORS 문제 해결
+   */
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8080/api/:path*',
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,129 @@
+/**
+ * Session 기반 인증 API 클라이언트
+ * 
+ * - credentials: 'include'로 세션 쿠키 자동 전송
+ * - 공통 헤더 설정
+ * - 에러 처리 통합
+ */
+
+import { ApiError } from './error';
+
+/**
+ * API 요청 옵션 타입
+ */
+interface ApiOptions extends Omit<RequestInit, 'body'> {
+  /** 쿼리 파라미터 */
+  params?: Record<string, string | number | boolean | undefined>;
+  /** JSON으로 변환할 요청 본문 */
+  body?: unknown;
+}
+
+/**
+ * 기본 API 호출 함수
+ * @param endpoint - API 엔드포인트 (예: '/items', '/users/1')
+ * @param options - 요청 옵션
+ * @returns 응답 데이터
+ */
+async function apiClient<T>(
+  endpoint: string,
+  options: ApiOptions = {}
+): Promise<T> {
+  const { params, body, headers, ...restOptions } = options;
+
+  // URL 생성 (쿼리 파라미터 포함)
+  let url = `/api/v1${endpoint}`;
+  if (params) {
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        searchParams.append(key, String(value));
+      }
+    });
+    const queryString = searchParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+  }
+
+  // fetch 요청
+  const response = await fetch(url, {
+    ...restOptions,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    credentials: 'include', // 세션 쿠키 자동 전송
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  // 에러 처리
+  if (!response.ok) {
+    // 응답 본문 파싱 시도
+    let errorData: unknown;
+    try {
+      errorData = await response.json();
+    } catch {
+      errorData = null;
+    }
+
+    // 401: 로그인 필요 → 로그인 페이지로 이동
+    if (response.status === 401) {
+      // 이미 로그인 페이지면 무한 리다이렉트 방지
+      if (typeof window !== 'undefined' && !window.location.pathname.includes('/login')) {
+        window.location.href = '/login';
+      }
+    }
+
+    throw new ApiError(response.status, response.statusText, errorData);
+  }
+
+  // 204 No Content 처리
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  return response.json();
+}
+
+/**
+ * API 편의 함수
+ */
+export const api = {
+  /**
+   * GET 요청
+   * @example api.get<Item[]>('/items')
+   * @example api.get<Item[]>('/items', { page: 1, size: 10 })
+   */
+  get: <T>(endpoint: string, params?: Record<string, string | number | boolean | undefined>) =>
+    apiClient<T>(endpoint, { method: 'GET', params }),
+
+  /**
+   * POST 요청
+   * @example api.post<Item>('/items', { itemName: '노트북', unitPrice: 1500000 })
+   */
+  post: <T>(endpoint: string, body?: unknown) =>
+    apiClient<T>(endpoint, { method: 'POST', body }),
+
+  /**
+   * PUT 요청
+   * @example api.put<Item>('/items/1', { itemName: '노트북 Pro' })
+   */
+  put: <T>(endpoint: string, body?: unknown) =>
+    apiClient<T>(endpoint, { method: 'PUT', body }),
+
+  /**
+   * PATCH 요청
+   * @example api.patch<Item>('/items/1', { useYn: 'N' })
+   */
+  patch: <T>(endpoint: string, body?: unknown) =>
+    apiClient<T>(endpoint, { method: 'PATCH', body }),
+
+  /**
+   * DELETE 요청
+   * @example api.delete<void>('/items/1')
+   */
+  delete: <T>(endpoint: string) =>
+    apiClient<T>(endpoint, { method: 'DELETE' }),
+};
+
+export default api;

--- a/frontend/src/lib/api/error.ts
+++ b/frontend/src/lib/api/error.ts
@@ -1,0 +1,87 @@
+/**
+ * API 에러 처리 유틸리티
+ */
+
+/**
+ * API 에러 클래스
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    public data?: unknown
+  ) {
+    super(`API Error: ${status} ${statusText}`);
+    this.name = 'ApiError';
+  }
+}
+
+/**
+ * HTTP 상태 코드별 기본 에러 메시지
+ */
+const ERROR_MESSAGES: Record<number, string> = {
+  400: '입력 정보를 확인해주세요.',
+  401: '로그인이 필요합니다.',
+  403: '접근 권한이 없습니다.',
+  404: '요청한 데이터를 찾을 수 없습니다.',
+  409: '이미 존재하는 데이터입니다.',
+  500: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+  502: '서버에 연결할 수 없습니다.',
+  503: '서비스를 일시적으로 사용할 수 없습니다.',
+};
+
+/**
+ * 에러에서 사용자 친화적 메시지 추출
+ */
+export function getErrorMessage(error: unknown): string {
+  // ApiError인 경우
+  if (error instanceof ApiError) {
+    // 서버에서 보낸 메시지가 있으면 우선 사용
+    if (error.data && typeof error.data === 'object') {
+      const data = error.data as Record<string, unknown>;
+      if (typeof data.message === 'string' && data.message) {
+        return data.message;
+      }
+    }
+    // 상태 코드별 기본 메시지
+    return ERROR_MESSAGES[error.status] || `오류가 발생했습니다. (${error.status})`;
+  }
+
+  // 일반 Error인 경우
+  if (error instanceof Error) {
+    return error.message || '오류가 발생했습니다.';
+  }
+
+  // 그 외
+  return '알 수 없는 오류가 발생했습니다.';
+}
+
+/**
+ * 에러 알림 표시
+ * 나중에 Toast 컴포넌트로 교체 가능
+ */
+export function showError(error: unknown): void {
+  const message = getErrorMessage(error);
+  alert(message);
+}
+
+/**
+ * 401 에러인지 확인
+ */
+export function isUnauthorizedError(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 401;
+}
+
+/**
+ * 403 에러인지 확인
+ */
+export function isForbiddenError(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 403;
+}
+
+/**
+ * 404 에러인지 확인
+ */
+export function isNotFoundError(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404;
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,0 +1,5 @@
+/**
+ * API 모듈 export
+ */
+export { api, default } from './client';
+export * from './error';

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -1,0 +1,105 @@
+/**
+ * 포맷팅 유틸리티 함수
+ * 숫자, 통화, 날짜를 화면에 보기 좋게 변환합니다.
+ */
+
+/**
+ * 숫자 포맷팅 (천단위 콤마)
+ * @example formatNumber(1500000) → "1,500,000"
+ */
+export const formatNumber = (num: number): string => {
+  if (num === null || num === undefined || isNaN(num)) return '0';
+  return new Intl.NumberFormat('ko-KR').format(num);
+};
+
+/**
+ * 통화 포맷팅 (원화)
+ * @example formatCurrency(1500000) → "₩1,500,000"
+ */
+export const formatCurrency = (num: number): string => {
+  if (num === null || num === undefined || isNaN(num)) return '₩0';
+  return `₩${formatNumber(num)}`;
+};
+
+/**
+ * 날짜 포맷팅
+ * @example formatDate('2024-12-31') → "2024. 12. 31."
+ */
+export const formatDate = (date: string | Date | null | undefined): string => {
+  if (!date) return '';
+  try {
+    return new Intl.DateTimeFormat('ko-KR').format(new Date(date));
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * 날짜+시간 포맷팅
+ * @example formatDateTime('2024-12-31T14:30:00') → "2024. 12. 31. 오후 2:30"
+ */
+export const formatDateTime = (date: string | Date | null | undefined): string => {
+  if (!date) return '';
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(date));
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * 날짜를 YYYY-MM-DD 형식으로 변환 (input[type="date"]용)
+ * @example formatDateInput(new Date()) → "2024-12-31"
+ */
+export const formatDateInput = (date: Date | string | null | undefined): string => {
+  if (!date) return '';
+  try {
+    const d = new Date(date);
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * 전화번호 포맷팅
+ * @example formatPhoneNumber('01012345678') → "010-1234-5678"
+ */
+export const formatPhoneNumber = (phone: string | null | undefined): string => {
+  if (!phone) return '';
+  const cleaned = phone.replace(/\D/g, '');
+  
+  if (cleaned.length === 11) {
+    return cleaned.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+  } else if (cleaned.length === 10) {
+    return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+  } else if (cleaned.length === 9) {
+    return cleaned.replace(/(\d{2})(\d{3})(\d{4})/, '$1-$2-$3');
+  }
+  
+  return phone;
+};
+
+/**
+ * 사업자등록번호 포맷팅
+ * @example formatBusinessNumber('1234567890') → "123-45-67890"
+ */
+export const formatBusinessNumber = (num: string | null | undefined): string => {
+  if (!num) return '';
+  const cleaned = num.replace(/\D/g, '');
+  
+  if (cleaned.length === 10) {
+    return cleaned.replace(/(\d{3})(\d{2})(\d{5})/, '$1-$2-$3');
+  }
+  
+  return num;
+};

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Utils 모듈 export
+ */
+export * from './format';


### PR DESCRIPTION
## 작업한 내용

✅ 공통 유틸리티 함수 추가 (`lib/utils/format.ts`)
- formatNumber: 숫자 천단위 콤마 포맷팅
- formatCurrency: 원화 포맷팅
- formatDate: 날짜 포맷팅
- formatPhoneNumber: 전화번호 포맷팅
- formatBusinessNumber: 사업자등록번호 포맷팅

✅ Session 기반 API 클라이언트 구축 (`lib/api/client.ts`)
- credentials: 'include'로 세션 쿠키 자동 전송
- GET, POST, PUT, PATCH, DELETE 메서드 지원
- 쿼리 파라미터 자동 처리

✅ API 에러 처리 유틸리티 (`lib/api/error.ts`)
- HTTP 상태 코드별 사용자 친화적 메시지 변환
- ApiError 클래스 정의

✅ Next.js CORS 프록시 설정 (`next.config.ts`)
- 개발 환경에서 /api/* 요청을 localhost:8080으로 프록시

## 변경 사항
⚠️ **백엔드 연동 시 필수 사용**
- 모든 API 호출은 `lib/api/client.ts`의 `api` 객체 사용
- 숫자/날짜 포맷팅은 `lib/utils/format.ts` 함수 사용

⚠️ **환경변수 설정 필요**
- `.env.local` 파일에 `NEXT_PUBLIC_API_URL=/api/v1` 설정 권장
## 참고사항
- 4명 협업 시 코드 중복 방지를 위한 공통 모듈
- 백엔드 구현 전에 미리 준비하여 일관된 API 호출 패턴 확립
- TypeScript 타입 체크 완료 (에러 없음)

## 관련 이슈
Resolves: #19 