### PR TITLE
[Refactor] SessionUser에 사용자명/부서 정보 포함

### DIFF
--- a/src/main/java/com/company/erp/common/login/service/LoginService.java
+++ b/src/main/java/com/company/erp/common/login/service/LoginService.java
@@ -39,13 +39,16 @@ public class LoginService {
             throw new IllegalArgumentException("아이디 또는 비밀번호가 올바르지 않습니다.");
         }
 
-        String comType = (String) user.get("comType");
-        String vendorCd = (String) user.get("vendorCd");
+        String comType   = (String) user.get("comType");
+        String vendorCd  = (String) user.get("vendorCd");
+        String userName  = (String) user.get("userName");
+        String deptCd    = (String) user.get("deptCd");
+        String deptName  = (String) user.get("deptName");
 
         if (comType == null || comType.isBlank()) {
             throw new IllegalStateException("로그인 처리 중 오류가 발생했습니다.");
         }
 
-        return new SessionUser(userId, ipAddress, comType, vendorCd);
+        return new SessionUser(userId, ipAddress, comType, vendorCd, userName, deptCd, deptName);
     }
 }

--- a/src/main/java/com/company/erp/common/session/SessionUser.java
+++ b/src/main/java/com/company/erp/common/session/SessionUser.java
@@ -17,5 +17,9 @@ public class SessionUser implements Serializable {
     private final String ipAddress;
     private final String comType;   // B: 구매사, V: 협력사
     private final String vendorCd;  // 협력사일 때만 값 있음
+
+    private final String userName;   // 사용자명
+    private final String deptCd;     // 부서코드
+    private final String deptName;   // 부서명
 }
 

--- a/src/main/resources/mapper/common/login/LoginMapper.xml
+++ b/src/main/resources/mapper/common/login/LoginMapper.xml
@@ -6,26 +6,35 @@
 
     <select id="findLoginUser" resultType="map">
         SELECT
-            'B'       AS comType,
-            NULL      AS vendorCd,
-            USER_ID   AS userId,
-            USER_PW   AS password
-        FROM by_user
-        WHERE USER_ID = #{userId}
-          AND DEL_FLAG = 'N'
+            'B'               AS comType,
+            NULL              AS vendorCd,
+            u.USER_ID         AS userId,
+            u.USER_PW         AS password,
+            u.USER_NM         AS userName,
+            u.DEPT_CD         AS deptCd,
+            d.DEPT_NM         AS deptName
+        FROM by_user u
+                 LEFT JOIN dept d
+                           ON d.DEPT_CD  = u.DEPT_CD
+                               AND d.DEL_FLAG = 'N'
+        WHERE u.USER_ID  = #{userId}
+          AND u.DEL_FLAG = 'N'
 
         UNION ALL
 
         SELECT
-            'V'        AS comType,
-            VENDOR_CD  AS vendorCd,
-            USER_ID    AS userId,
-            PASSWORD   AS password
-        FROM vn_user
-        WHERE USER_ID = #{userId}
-          AND DEL_FLAG = 'N'
+            'V'               AS comType,
+            v.VENDOR_CD       AS vendorCd,
+            v.USER_ID         AS userId,
+            v.PASSWORD        AS password,
+            v.USER_NM         AS userName,
+            NULL              AS deptCd,
+            NULL              AS deptName
+        FROM vn_user v
+        WHERE v.USER_ID  = #{userId}
+          AND v.DEL_FLAG = 'N'
 
-        LIMIT 1
+            LIMIT 1
     </select>
 
 </mapper>


### PR DESCRIPTION
## **작업한 내용**

-  SessionUser에 사용자명/부서 정보 필드 추가  
-  로그인 시 사용자 및 부서 정보 조회 후 세션에 저장  
-  구매사 단일 구조에 맞게 부서 조인 조건 정리  

## **변경 사항**

- SessionUser 생성자 시그니처 변경
- 로그인 SQL에서 dept_cd 기준으로 dept_nm 조회
- 구매사 단일 전제에 따라 buyer_cd 조인 제거

## **참고사항**

- PR/발주/입고 등 문서 생성 시 세션 기반 사용자·부서 자동 세팅을 위한 구조 개선
- 기존 API 스펙에는 영향 없음

## **관련 이슈**

Resolves: #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 세션에 사용자명, 부서코드, 부서명 정보가 추가되어 더 상세한 사용자 정보가 관리됩니다.
  * 로그인 시 부서 정보를 함께 조회하여 사용자 세션 데이터가 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->