### PR TITLE
[Refactor] 세션 로그인 사용자 키 상수화 (SessionUser.class.getName() 제거)

### DIFF
--- a/src/main/java/com/company/erp/common/file/controller/FileController.java
+++ b/src/main/java/com/company/erp/common/file/controller/FileController.java
@@ -3,6 +3,7 @@ package com.company.erp.common.file.controller;
 import com.company.erp.common.exception.ApiResponse;
 import com.company.erp.common.file.dto.FileListItemResponse;
 import com.company.erp.common.file.service.FileService;
+import com.company.erp.common.session.SessionConst;
 import com.company.erp.common.session.SessionUser;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -67,7 +68,7 @@ public class FileController {
 
     private SessionUser getSessionUser(HttpSession session) {
         if (session == null) return null;
-        Object obj = session.getAttribute(SessionUser.class.getName());
+        Object obj = session.getAttribute(SessionConst.LOGIN_USER);
         return (obj instanceof SessionUser) ? (SessionUser) obj : null;
     }
 }

--- a/src/main/java/com/company/erp/common/login/controller/LoginController.java
+++ b/src/main/java/com/company/erp/common/login/controller/LoginController.java
@@ -4,6 +4,7 @@ import com.company.erp.common.exception.ApiResponse;
 import com.company.erp.common.login.dto.LoginRequest;
 import com.company.erp.common.login.service.DuplicateLoginService;
 import com.company.erp.common.login.service.LoginService;
+import com.company.erp.common.session.SessionConst;
 import com.company.erp.common.session.SessionIgnore;
 import com.company.erp.common.session.SessionUser;
 import jakarta.servlet.http.HttpServletRequest;
@@ -60,7 +61,7 @@ public class LoginController {
         if (session == null) {
             return ApiResponse.fail("세션이 존재하지 않습니다.");
         }
-        SessionUser user = (SessionUser) session.getAttribute(SessionUser.class.getName());
+        SessionUser user = (SessionUser) session.getAttribute(SessionConst.LOGIN_USER);
 
         if (user == null) {
             return ApiResponse.fail("세션이 존재하지 않습니다.");

--- a/src/main/java/com/company/erp/common/login/controller/LogoutController.java
+++ b/src/main/java/com/company/erp/common/login/controller/LogoutController.java
@@ -1,6 +1,7 @@
 package com.company.erp.common.login.controller;
 
 import com.company.erp.common.exception.ApiResponse;
+import com.company.erp.common.session.SessionConst;
 import com.company.erp.common.session.SessionRegistry;
 import com.company.erp.common.session.SessionUser;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,7 +26,7 @@ public class LogoutController {
 
         String sessionId = session.getId();
 
-        Object sessionAttr = session.getAttribute(SessionUser.class.getName());
+        Object sessionAttr = session.getAttribute(SessionConst.LOGIN_USER);
         SessionUser sessionUser = (sessionAttr instanceof SessionUser) ? (SessionUser) sessionAttr : null;
 
         if (sessionUser != null) {

--- a/src/main/java/com/company/erp/common/login/service/DuplicateLoginService.java
+++ b/src/main/java/com/company/erp/common/login/service/DuplicateLoginService.java
@@ -1,5 +1,6 @@
 package com.company.erp.common.login.service;
 
+import com.company.erp.common.session.SessionConst;
 import com.company.erp.common.session.SessionRegistry;
 import com.company.erp.common.session.SessionUser;
 import jakarta.servlet.http.HttpSession;
@@ -28,6 +29,6 @@ public class DuplicateLoginService {
         sessionRegistry.registerLogin(userId, currentSessionId);
 
         // 4) 현재 세션에 로그인 사용자 저장
-        currentSession.setAttribute(SessionUser.class.getName(), loginUser);
+        currentSession.setAttribute(SessionConst.LOGIN_USER, loginUser);
     }
 }

--- a/src/main/java/com/company/erp/common/session/SessionConst.java
+++ b/src/main/java/com/company/erp/common/session/SessionConst.java
@@ -5,4 +5,6 @@ public final class SessionConst {
 
     public static final int STATUS_NO_SESSION = 440;
     public static final int STATUS_MULTI_LOGIN = 441;
+
+    public static final String LOGIN_USER = "LOGIN_USER";
 }

--- a/src/main/java/com/company/erp/common/session/SessionInterceptor.java
+++ b/src/main/java/com/company/erp/common/session/SessionInterceptor.java
@@ -49,7 +49,7 @@ public class SessionInterceptor implements HandlerInterceptor {
         }
 
         // 3) 로그인 사용자 확인
-        Object sessionAttr = session.getAttribute(SessionUser.class.getName());
+        Object sessionAttr = session.getAttribute(SessionConst.LOGIN_USER);
         SessionUser loginUser = (sessionAttr instanceof SessionUser) ? (SessionUser) sessionAttr : null;
         if (loginUser == null) {
             // 세션은 있는데 loginUser가 없으면 registry 찌꺼기 정리(만료/비정상 세션 방어)

--- a/src/main/java/com/company/erp/inventory/service/GoodsReceiptService.java
+++ b/src/main/java/com/company/erp/inventory/service/GoodsReceiptService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import com.company.erp.common.session.SessionConst;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -262,7 +263,7 @@ public class GoodsReceiptService {
 
     // 세션에서 로그인 사용자 정보 가져오기
     private SessionUser getSessionUser() {
-        Object sessionAttr = httpSession.getAttribute(SessionUser.class.getName());
+        Object sessionAttr = httpSession.getAttribute(SessionConst.LOGIN_USER);
         return (sessionAttr instanceof SessionUser) ? (SessionUser) sessionAttr : null;
     }
 

--- a/src/main/java/com/company/erp/po/service/PurchaseOrderService.java
+++ b/src/main/java/com/company/erp/po/service/PurchaseOrderService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import com.company.erp.common.session.SessionConst;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -159,7 +160,7 @@ public class PurchaseOrderService {
 
     // 세션에서 로그인 사용자 정보 가져오기
     private SessionUser getSessionUser() {
-        Object sessionAttr = httpSession.getAttribute(SessionUser.class.getName());
+        Object sessionAttr = httpSession.getAttribute(SessionConst.LOGIN_USER);
         return (sessionAttr instanceof SessionUser) ? (SessionUser) sessionAttr : null;
     }
 

--- a/src/main/java/com/company/erp/pr/controller/PrController.java
+++ b/src/main/java/com/company/erp/pr/controller/PrController.java
@@ -1,5 +1,6 @@
 package com.company.erp.pr.controller;
 
+import com.company.erp.common.session.SessionConst;
 import com.company.erp.common.session.SessionUser;
 import com.company.erp.pr.dto.PrItemDTO;
 import com.company.erp.pr.dto.PrListResponse;
@@ -24,7 +25,7 @@ public class PrController {
     //구매요청화면 초기 데이터 조회
     @GetMapping("/init")
     public ResponseEntity<Map<String,Object>> initPurchase(HttpSession httpSession){
-        SessionUser user = (SessionUser) httpSession.getAttribute(SessionUser.class.getName());
+        SessionUser user = (SessionUser) httpSession.getAttribute(SessionConst.LOGIN_USER);
         String userId = user.getUserId();
         String deptName = user.getDeptName();
 
@@ -53,7 +54,7 @@ public class PrController {
     public ResponseEntity<Map<String,String>> savePurchaseRequest(HttpSession httpSession,
                                                                   @RequestBody PrRequest prRequest){
 
-        SessionUser user = (SessionUser) httpSession.getAttribute(SessionUser.class.getName());
+        SessionUser user = (SessionUser) httpSession.getAttribute(SessionConst.LOGIN_USER);
         String userId = user.getUserId();
         String deptCd = user.getDeptCd();
 


### PR DESCRIPTION
## **작업한 내용**

- 로그인 사용자 세션 키를 SessionUser.class.getName() 방식에서 SessionConst.LOGIN_USER 상수 기반으로 통합
- 세션 저장/조회 관련 코드 전반에서 키 사용 방식 일원화
- 세션 정책 가독성 및 리팩토링 안정성 개선

## **변경 사항**
- 세션 attribute key가 변경됨 (SessionUser.class.getName() → SessionConst.LOGIN_USER)
- 기존 로그인/중복 로그인/세션 인터셉터 흐름에는 영향 없음
- 기능 변경 없이 리팩토링만 수행

## **관련 이슈**
Resolves: #136 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 세션 사용자 정보 접근 방식을 표준화하여 코드 유지보수성을 개선했습니다. 사용자에게 보이는 기능상 변화는 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->