### PR TITLE
[Feat] 협력업체 추가/삭제 API 분리

### DIFF
--- a/src/main/java/com/company/erp/rfq/buyer/vendor/controller/RfqBuyerVendorController.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/controller/RfqBuyerVendorController.java
@@ -1,0 +1,23 @@
+package com.company.erp.rfq.buyer.vendor.controller;
+
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorSearchRequest;
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorListResponse;
+import com.company.erp.rfq.buyer.vendor.service.RfqBuyerVendorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/buyer/rfqs/vendors")
+@RequiredArgsConstructor
+public class RfqBuyerVendorController {
+
+    private final RfqBuyerVendorService service;
+
+    @GetMapping
+    public ResponseEntity<RfqVendorListResponse> getApprovedVendors(RfqVendorSearchRequest request) {
+        return ResponseEntity.ok(service.getApprovedVendors(request));
+    }
+}

--- a/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorClasses.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorClasses.java
@@ -1,0 +1,12 @@
+package com.company.erp.rfq.buyer.vendor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+public class RfqVendorClasses {
+    // 파일 분리 대신 inner class나 한 파일에 모을 수도 있지만, 관례상 분리가 좋음.
+    // 여기서는 편의를 위해 일단 각각 생성하도록 명령 분할 예정
+}

--- a/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorDTO.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorDTO.java
@@ -1,0 +1,13 @@
+package com.company.erp.rfq.buyer.vendor.dto;
+
+import lombok.Data;
+
+@Data
+public class RfqVendorDTO {
+    private String vendorCode;
+    private String vendorName;
+    private String ceoName;
+    private String address;
+    private String industry;
+    private String status;
+}

--- a/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorListResponse.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorListResponse.java
@@ -1,0 +1,16 @@
+package com.company.erp.rfq.buyer.vendor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RfqVendorListResponse {
+    private List<RfqVendorDTO> vendors;
+    private int totalCount;
+}

--- a/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorSearchRequest.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/dto/RfqVendorSearchRequest.java
@@ -1,0 +1,9 @@
+package com.company.erp.rfq.buyer.vendor.dto;
+
+import lombok.Data;
+
+@Data
+public class RfqVendorSearchRequest {
+    private String vendorCode;
+    private String vendorName;
+}

--- a/src/main/java/com/company/erp/rfq/buyer/vendor/mapper/RfqBuyerVendorMapper.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/mapper/RfqBuyerVendorMapper.java
@@ -1,0 +1,11 @@
+package com.company.erp.rfq.buyer.vendor.mapper;
+
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorDTO;
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorSearchRequest;
+import org.apache.ibatis.annotations.Mapper;
+import java.util.List;
+
+@Mapper
+public interface RfqBuyerVendorMapper {
+    List<RfqVendorDTO> selectApprovedVendors(RfqVendorSearchRequest request);
+}

--- a/src/main/java/com/company/erp/rfq/buyer/vendor/service/RfqBuyerVendorService.java
+++ b/src/main/java/com/company/erp/rfq/buyer/vendor/service/RfqBuyerVendorService.java
@@ -1,0 +1,28 @@
+package com.company.erp.rfq.buyer.vendor.service;
+
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorDTO;
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorListResponse;
+import com.company.erp.rfq.buyer.vendor.dto.RfqVendorSearchRequest;
+import com.company.erp.rfq.buyer.vendor.mapper.RfqBuyerVendorMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RfqBuyerVendorService {
+
+    private final RfqBuyerVendorMapper mapper;
+
+    @Transactional(readOnly = true)
+    public RfqVendorListResponse getApprovedVendors(RfqVendorSearchRequest request) {
+        // 페이징이나 카운트 없이 단순 리스트 반환 (필요 시 확장)
+        List<RfqVendorDTO> vendors = mapper.selectApprovedVendors(request);
+        return RfqVendorListResponse.builder()
+                .vendors(vendors)
+                .totalCount(vendors.size()) // 전체 카운트 쿼리는 생략 (단순 목록)
+                .build();
+    }
+}


### PR DESCRIPTION
## **작업한 내용**
- 협력업체 현황에서 쓰는 API를 RFQ에서 전용으로 승인된 업체만 보일 수 있게 API 분리

## **관련 이슈**
Resolves: #185 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * RFQ(견적 요청) 프로세스에서 승인된 공급업체를 검색하고 조회할 수 있는 API 추가
  * 공급업체 코드 및 이름을 기반으로 한 고급 검색 기능 구현

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->